### PR TITLE
クラウド環境にデプロイできるようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
 identidock:
-  build: .
+  image: amouat/identidock:1.0
   ports:
     - "5000:5000"
+    - "9000:9000"
   environment:
     ENV: DEV
-  volumes:
-    - ./app:/app
   links:
     - dnmonster
     - redis

--- a/identiproxy/Dockerfile
+++ b/identiproxy/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:1.14
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/identiproxy/default.conf
+++ b/identiproxy/default.conf
@@ -1,0 +1,14 @@
+server {
+  listen 80;
+  server_name {{NGINX_HOST}};
+
+  location / {
+    proxy_pass {{NGINX_PROXY}};
+    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_set_header  Host            {{NGINX_HOST}};
+    proxy_set_header  X-Real-IP       $remote_addr;
+    proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}

--- a/identiproxy/entrypoint.sh
+++ b/identiproxy/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+sed -i "s|{{NGINX_HOST}}|$NGINX_HOST|;s|{{NGINX_PROXY}}|$NGINX_PROXY|" /etc/nginx/conf.d/default.conf
+cat /etc/nginx/conf.d/default.conf
+exec "$@"

--- a/prod.yml
+++ b/prod.yml
@@ -1,0 +1,23 @@
+proxy:
+  image: proxy:1.0
+  links:
+    - identidock
+  ports:
+    - "80:80"
+  environment:
+    - NGINX_HOST=(your cloud host's ip_address)
+    - NGINX_PROXY=http://identidock:9090
+
+identidock:
+  image: amouat/identidock:1.0
+  links:
+    - dnmonster
+    - redis
+  environment:
+    ENV: PROD
+
+dnmonster:
+  image: amouat/dnmonster:1.0
+
+redis:
+  image: redis:4.0


### PR DESCRIPTION
## 変更点

- 開発環境をcloudにデプロイするための設定変更
  - DockerHubにあるイメージを利用
  - volumeの設定を削除
  - 9000 番ポートを開放
- 本番環境用のnginxプロキシコンテナを追加
- 本番環境用のcomposeファイルを追加
  - 80 番ポートのみ外部に公開する