### PR TITLE
Syslog を使ってログをフォワードする

### DIFF
--- a/30-docker.conf
+++ b/30-docker.conf
@@ -1,0 +1,2 @@
+:syslogtag,startswith,"docker/" @@localhost:5544
+&stop

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,2 @@
+docker-machine scp logstash.conf identihost-do:/.
+docker-machine scp 30-docker.conf identihost-do:/etc/rsyslog.d/.

--- a/logstash.conf
+++ b/logstash.conf
@@ -18,5 +18,4 @@ output {
   elasticsearch {
     hosts => ["elasticsearch"]
   }
-  stdout { codec => rubydebug }
 }

--- a/logstash.conf
+++ b/logstash.conf
@@ -1,11 +1,7 @@
 input {
-  tcp {
-    port  => 5000
-    codec => json
-  }
-  udp {
-    port => 5000
-    codec => json
+  syslog {
+    type => syslog
+    port => 5544
   }
 }
 

--- a/logstash.conf
+++ b/logstash.conf
@@ -6,10 +6,10 @@ input {
 }
 
 filter {
-  if [docker.image] =~ /^amouat\/proxy.*/ {
-    mutate { replace => { type => "nginx" } }
-    grok {
-      match => { "message" => "%{COMBINEDAPACHELOG}" }
+  if [type] == "syslog" {
+    syslog_pri { }
+    date {
+      match => [ "syslog_timestamp", "MMM d HH:mm:ss", "MMM dd HH:mm:ss" ]
     }
   }
 }

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -62,3 +62,4 @@ kibana:
     - elasticsearch
   ports:
     - "5601:5601"
+  log_driver: json-file

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -7,6 +7,9 @@ proxy:
   environment:
     - NGINX_HOST=(your host's ip address)
     - NGINX_PROXY=http://identidock:9090
+  log_driver: syslog
+  log_opt:
+    tag: docker/{{.ImageName}}/{{.Name}}/{{.ID}}
 
 identidock:
   image: amouat/identidock:1.0

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -45,6 +45,7 @@ logstash:
   ports:
     - "127.0.0.1:5544:5544"
   command: -f /etc/logstash.conf
+  log_driver: json-file
 
 elasticsearch:
   image: elasticsearch:2.4.6

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -22,16 +22,6 @@ dnmonster:
 redis:
   image: redis:4.0
 
-logspout:
-  image: amouat/logspout-logstash
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock
-  ports:
-    - "8000:80"
-  links:
-    - logstash
-  command: logstash://logstash:5000
-
 logstash:
   image: logstash:2.4.1
   volumes:

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -51,6 +51,7 @@ elasticsearch:
   image: elasticsearch:2.4.6
   environment:
     LOGSPOUT: ignore
+  log_driver: json-file
 
 kibana:
   image: kibana:4

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -30,6 +30,8 @@ logstash:
     LOGSPOUT: ignore
   links:
     - elasticsearch
+  ports:
+    - "127.0.0.1:5544:5544"
   command: -f /etc/logstash.conf
 
 elasticsearch:

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -30,6 +30,9 @@ dnmonster:
 
 redis:
   image: redis:4.0
+  log_driver: syslog
+  log_opt:
+    tag: docker/{{.ImageName}}/{{.Name}}/{{.ID}}
 
 logstash:
   image: logstash:2.4.1

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -24,6 +24,9 @@ identidock:
 
 dnmonster:
   image: amouat/dnmonster:1.0
+  log_driver: syslog
+  log_opt:
+    tag: docker/{{.ImageName}}/{{.Name}}/{{.ID}}
 
 redis:
   image: redis:4.0

--- a/prod-with-logging.yml
+++ b/prod-with-logging.yml
@@ -18,6 +18,9 @@ identidock:
     - redis
   environment:
     ENV: PROD
+  log_driver: syslog
+  log_opt:
+    tag: docker/{{.ImageName}}/{{.Name}}/{{.ID}}
 
 dnmonster:
   image: amouat/dnmonster:1.0


### PR DESCRIPTION
## 概要

低速な louspout を使わず、 syslog から直接 logstash にログを転送する。

## 変更点

* syslog から 5544 番ポートにログをフォワードする
* logstash の 5544 番ポートをローカルホストに公開する
* 各 dockerコンテナのログドライバーを syslog にする